### PR TITLE
Add type to view.find call

### DIFF
--- a/lib/openlibrary/view.rb
+++ b/lib/openlibrary/view.rb
@@ -23,8 +23,8 @@ module Openlibrary
       find("OLID",key)
     end
 
-    def self.find(key)
-      response = RestClient.get "http://openlibrary.org/api/books?bibkeys=ISBN:#{key}&format=json&jscmd=viewapi"
+    def self.find(type,key)
+      response = RestClient.get "http://openlibrary.org/api/books?bibkeys=#{type}:#{key}&format=json&jscmd=viewapi"
 
       response_data = JSON.parse(response)
       view = response_data["#{type}:#{key}"]


### PR DESCRIPTION
Your view.find method was missing the type argument used for the api identifiers call.  This pull fixes that bug.
