### PR TITLE
Update README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -58,7 +58,7 @@ You can also retrieve a book's full metadata details.
   book_details.title
 
   # or an array of authors 
-  book_view.authors
+  book_details.authors
 
 == CONTRIBUTORS
 


### PR DESCRIPTION
There was a typo under `# or an array of authors`: `book_view.authors` should be `book_details.authors`
