### PR TITLE
Remove www

### DIFF
--- a/lib/openlibrary/request.rb
+++ b/lib/openlibrary/request.rb
@@ -61,7 +61,6 @@ module Openlibrary
       params.merge!(accept: :json)
       url = "#{API_URL}/query.json?#{query}"
       resp = RestClient.get(url, params) do |response, request, result, &block|
-        puts response
         case response.code
         when 200
           response.return!(request, result, &block)


### PR DESCRIPTION
Was getting an error on every API call, apparently because of a 302 response code. In debugging I found that removing the "www" from the API_URL resolved the issue.
