### PR TITLE
Removes merge conflict markings at README.rdoc and adds ruby version badge link

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 == Openlibrary
 
-[![Gem Version](https://badge.fury.io/rb/openlibrary.png)](http://badge.fury.io/rb/openlibrary)
+{<img src="https://badge.fury.io/rb/openlibrary.png" alt="Gem Version" />}[http://badge.fury.io/rb/openlibrary]
 
 The openlibrary gem provides Ruby clients for the {Open Library REST API}[http://openlibrary.org/dev/docs/restful_api] and {Books API}[http://openlibrary.org/dev/docs/api/books].
 


### PR DESCRIPTION
See bottom part of README.rdoc for merge conflict markings.
