### PR TITLE
Fix for https://github.com/jayfajardo/openlibrary/issues/16

### DIFF
--- a/lib/openlibrary/errors.rb
+++ b/lib/openlibrary/errors.rb
@@ -2,4 +2,5 @@ module Openlibrary
   class Error         < StandardError; end
   class Unauthorized  < Error; end
   class NotFound      < Error; end
+  class Redirect      < Error; end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -44,8 +44,8 @@ describe 'Client' do
       book.subjects[1].should eq              'First loves -- Fiction'
       book.subjects[0].should eq              'Traffic accidents -- Fiction'
 
-      # Because of a conflict with the internal `key?` method of 
-      # Hashie::Mash, any key actually named 'key' must be referenced 
+      # Because of a conflict with the internal `key?` method of
+      # Hashie::Mash, any key actually named 'key' must be referenced
       # with a bang (!) to get the value.
       book.key!.should eq                     '/books/OL23109860M'
       book.languages[0].key!.should eq           '/languages/eng'
@@ -56,7 +56,7 @@ describe 'Client' do
     before do
       isbn_10 = '046503912X'
       type = '/type/edition'
-      stub_get("/query.json?type=#{type}&isbn_10=#{isbn_10}", 
+      stub_get("/query.json?type=#{type}&isbn_10=#{isbn_10}",
                'book_by_isbn.json')
     end
     it 'returns array of books' do
@@ -66,7 +66,7 @@ describe 'Client' do
 
       books = client.book_by_isbn('046503912X')
 
-      books.should be_a Array 
+      books.should be_a Array
       books[0].should be_a Hash
 
       books[0]['key'].should eq '/books/OL6807502M'
@@ -115,7 +115,7 @@ describe 'Client' do
 
     it 'returns author details' do
       expect { client.author('OL1A') }.not_to raise_error
-      
+
       author = client.author('OL1A')
 
       author.should be_a Hashie::Mash
@@ -128,8 +128,8 @@ describe 'Client' do
       author.id.should eq                  97
       author.revision.should eq            6
 
-      # Because of a conflict with the internal `key?` method of 
-      # Hashie::Mash, any key actually named 'key' must be referenced 
+      # Because of a conflict with the internal `key?` method of
+      # Hashie::Mash, any key actually named 'key' must be referenced
       # with a bang (!) to get the value.
       author.key!.should eq                '/authors/OL1A'
     end
@@ -219,7 +219,7 @@ describe 'Client' do
 
   describe '#login' do
     before do
-      stub_http_request(:post, "openlibrary.org/account/login").
+      stub_http_request(:post, "https://openlibrary.org/account/login").
         with( body: "{\"username\":\"username\",\"password\":\"password\"}" ).
         to_return( status: 200, headers: {'Set-Cookie' => 'session=cookie'} )
     end


### PR DESCRIPTION
## Problem
- Received `302` redirects when attempting to access `openlibrary.org` using this client.
- `302` are not handled in the case statements, so the response was returning `nil`
## Summary of changes
- Updated the `API_URL` for open library to use secure `https`
- Added `HANDLE_REST_CLIENT_RESPONSE` lamda to handle common response code actions
- Added a helper, `perform_get_request` for common GET request code
