### PR TITLE
Update hashie dependencies to >= 3.5.0

### DIFF
--- a/openlibrary.gemspec
+++ b/openlibrary.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'json',  '~> 2.5', '>= 2.5.1'
   s.add_runtime_dependency 'rest-client', '~> 2.0', '~> 2.0.1'
-  s.add_runtime_dependency 'hashie', '~> 2.0', '~> 2.0.2'
+  s.add_runtime_dependency 'hashie', '>= 3.5.0'
 
   s.add_runtime_dependency 'activesupport', '>= 6'
 end


### PR DESCRIPTION
Hi, I was already using the master version of this gem in my project. But when adding omniauth my application wasn't booting anymore, finally to realize that bundler install an old version of omniauth to satisfy the hashie dependencies, currently it required [>= 3.4.6](https://github.com/omniauth/omniauth/blob/d014c0e8af9ffa771f9f690d7313f46fdf5e94d0/omniauth.gemspec#L8).

This PR is simply to allow 3.5.0 and more (I don't really know which one to target, the build works with 3.0 and 5.0 of hashie).


