### PR TITLE
remove User-Agent header in stub to fix failing tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,8 +32,7 @@ def stub_put(path, fixture_name, comment)
         'Content-Type' => 'application/json',
         'Opt'          => '"http://openlibrary.org/dev/docs/api"; ns=42',
         '42-comment'   => comment,
-        'Cookie'       => 'cookie',
-        'User-Agent'   => 'Ruby'
+        'Cookie'       => 'cookie'
       }).
     to_return(
       status:  200,


### PR DESCRIPTION
RestClient provides machine generated User-Agent dependent on the machine it is run on (eg: 'rest-client/2.0.2 (darwin25 arm64) ruby/2.7.6p219'), causing tests to fail